### PR TITLE
Fix for Smart Pool rewards

### DIFF
--- a/contracts/utils/ExaLib.sol
+++ b/contracts/utils/ExaLib.sol
@@ -81,7 +81,7 @@ library ExaLib {
             uint256 exaAccruedDelta = deltaBlocks * supplySpeed;
             Double memory ratio = smartTokens > 0 ? exaAccruedDelta.fraction(smartTokens) : Double({value: 0});
             Double memory index = Double({value: smartState.index}).add_(ratio);
-            exaState.exaSupplyState = MarketRewardsState({
+            exaState.exaSmartState = MarketRewardsState({
                 index: index.value.toUint224(),
                 block: blockNumber.toUint32()
             });


### PR DESCRIPTION
* `exaSupplyState` was wrongly being overwritten with the newly calculated `exaSmartState`