### PR TITLE
Supply function now uses msg.sender as supplier

### DIFF
--- a/contracts/interfaces/IFixedLender.sol
+++ b/contracts/interfaces/IFixedLender.sol
@@ -5,10 +5,12 @@ import "./IAuditor.sol";
 import "./IEToken.sol";
 
 interface IFixedLender {
-    function borrow(uint256 amount, uint256 maturityDate) external;
+    function borrow(
+        uint256 amount, 
+        uint256 maturityDate
+    ) external;
 
     function supply(
-        address from,
         uint256 amount,
         uint256 maturityDate
     ) external;

--- a/test/1_auditor.ts
+++ b/test/1_auditor.ts
@@ -107,7 +107,7 @@ describe("Auditor from User Space", function () {
     const dai = exactlyEnv.getUnderlying("DAI");
     const amountDAI = parseUnits("100");
     await dai.approve(fixedLenderDAI.address, amountDAI);
-    await fixedLenderDAI.supply(owner.address, amountDAI, nextPoolID);
+    await fixedLenderDAI.supply(amountDAI, nextPoolID);
 
     // we make it count as collateral (DAI)
     await auditor.enterMarkets([fixedLenderDAI.address], nextPoolID);
@@ -124,7 +124,7 @@ describe("Auditor from User Space", function () {
     const dai = exactlyEnv.getUnderlying("DAI");
     const amountDAI = parseUnits("100");
     await dai.approve(fixedLenderDAI.address, amountDAI);
-    await fixedLenderDAI.supply(owner.address, amountDAI, nextPoolID);
+    await fixedLenderDAI.supply(amountDAI, nextPoolID);
 
     // we make it count as collateral (DAI)
     await auditor.enterMarkets([fixedLenderDAI.address], nextPoolID);
@@ -140,7 +140,7 @@ describe("Auditor from User Space", function () {
     const dai = exactlyEnv.getUnderlying("DAI");
     const amountDAI = parseUnits("100");
     await dai.approve(fixedLenderDAI.address, amountDAI);
-    await fixedLenderDAI.supply(owner.address, amountDAI, nextPoolID);
+    await fixedLenderDAI.supply(amountDAI, nextPoolID);
     await fixedLenderDAI.borrow(amountDAI.div(2), nextPoolID);
 
     // we make it count as collateral (DAI)
@@ -198,7 +198,7 @@ describe("Auditor from User Space", function () {
 
     const amountDAI = parseUnits("100");
     await dai.approve(fixedLenderDAI.address, amountDAI);
-    await fixedLenderDAI.supply(owner.address, amountDAI, nextPoolID);
+    await fixedLenderDAI.supply(amountDAI, nextPoolID);
 
     await auditor.enterMarkets([fixedLenderDAI.address], nextPoolID);
 
@@ -309,7 +309,7 @@ describe("Auditor from User Space", function () {
     // we supply Dai to the protocol
     const amountDAI = parseUnits("100");
     await dai.approve(fixedLenderDAI.address, amountDAI);
-    await fixedLenderDAI.supply(owner.address, amountDAI, nextPoolID);
+    await fixedLenderDAI.supply(amountDAI, nextPoolID);
 
     // we make it count as collateral (DAI)
     await auditor.enterMarkets([fixedLenderDAI.address], nextPoolID);
@@ -326,7 +326,7 @@ describe("Auditor from User Space", function () {
     // we supply Dai to the protocol
     const amountDAI = parseUnits("100");
     await dai.approve(fixedLenderDAI.address, amountDAI);
-    await fixedLenderDAI.supply(owner.address, amountDAI, nextPoolID);
+    await fixedLenderDAI.supply(amountDAI, nextPoolID);
 
     // we make it count as collateral (DAI)
     await expect(
@@ -353,7 +353,7 @@ describe("Auditor from User Space", function () {
     // we supply Dai to the protocol
     const amountDAI = parseUnits("100");
     await dai.approve(fixedLenderDAI.address, amountDAI);
-    await fixedLenderDAI.supply(owner.address, amountDAI, nextPoolID);
+    await fixedLenderDAI.supply(amountDAI, nextPoolID);
 
     await expect(
       // user tries to borrow more than the cap
@@ -389,11 +389,7 @@ describe("Auditor from User Space", function () {
     // we supply Dai to the protocol
     const amountDAI = parseUnits("100");
     await dai.approve(fixedLenderDAI.address, amountDAI);
-    let txDAI = await fixedLenderDAI.supply(
-      owner.address,
-      amountDAI,
-      nextPoolID
-    );
+    let txDAI = await fixedLenderDAI.supply(amountDAI, nextPoolID);
     let borrowDAIEvent = await parseSupplyEvent(txDAI);
 
     expect(await dai.balanceOf(fixedLenderDAI.address)).to.equal(amountDAI);
@@ -407,11 +403,7 @@ describe("Auditor from User Space", function () {
     // we supply Eth to the protocol
     const amountETH = parseUnits("1");
     await eth.approve(fixedLenderETH.address, amountETH);
-    let txETH = await fixedLenderETH.supply(
-      owner.address,
-      amountETH,
-      nextPoolID
-    );
+    let txETH = await fixedLenderETH.supply(amountETH, nextPoolID);
     let borrowETHEvent = await parseSupplyEvent(txETH);
 
     expect(await eth.balanceOf(fixedLenderETH.address)).to.equal(amountETH);
@@ -449,7 +441,7 @@ describe("Auditor from User Space", function () {
     // we supply Dai to the protocol
     const amountDAI = parseUnits("100");
     await dai.approve(fixedLenderDAI.address, amountDAI);
-    await fixedLenderDAI.supply(owner.address, amountDAI, nextPoolID);
+    await fixedLenderDAI.supply(amountDAI, nextPoolID);
 
     // we make it count as collateral (DAI)
     await auditor.enterMarkets([fixedLenderDAI.address], nextPoolID);

--- a/test/2_fixed_lender.ts
+++ b/test/2_fixed_lender.ts
@@ -96,11 +96,7 @@ describe("FixedLender", function () {
     const underlyingAmount = parseUnits("100");
     await underlyingToken.approve(fixedLender.address, underlyingAmount);
 
-    let tx = await fixedLender.supply(
-      owner.address,
-      underlyingAmount,
-      exaTime.nextPoolID()
-    );
+    let tx = await fixedLender.supply(underlyingAmount, exaTime.nextPoolID());
     let event = await parseSupplyEvent(tx);
 
     expect(event.from).to.equal(owner.address);
@@ -126,7 +122,7 @@ describe("FixedLender", function () {
     await underlyingToken.approve(fixedLender.address, underlyingAmount);
 
     await expect(
-      fixedLender.supply(owner.address, underlyingAmount, exaTime.pastPoolID())
+      fixedLender.supply(underlyingAmount, exaTime.pastPoolID())
     ).to.be.revertedWith(
       errorUnmatchedPool(PoolState.MATURED, PoolState.VALID)
     );
@@ -138,7 +134,7 @@ describe("FixedLender", function () {
     const notYetEnabledPoolID = exaTime.futurePools(12).pop()! + 86400 * 7; // 1 week after the last pool
 
     await expect(
-      fixedLender.supply(owner.address, underlyingAmount, notYetEnabledPoolID)
+      fixedLender.supply(underlyingAmount, notYetEnabledPoolID)
     ).to.be.revertedWith(
       errorUnmatchedPool(PoolState.NOT_READY, PoolState.VALID)
     );
@@ -149,7 +145,7 @@ describe("FixedLender", function () {
     await underlyingToken.approve(fixedLender.address, underlyingAmount);
     const invalidPoolID = exaTime.pastPoolID() + 666;
     await expect(
-      fixedLender.supply(owner.address, underlyingAmount, invalidPoolID)
+      fixedLender.supply(underlyingAmount, invalidPoolID)
     ).to.be.revertedWith(errorGeneric(ProtocolError.INVALID_POOL_ID));
   });
 
@@ -159,11 +155,7 @@ describe("FixedLender", function () {
     let underlyingTokenUser = underlyingToken.connect(mariaUser);
 
     await underlyingTokenUser.approve(fixedLender.address, parseUnits("1"));
-    await fixedLenderMaria.supply(
-      mariaUser.address,
-      parseUnits("1"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMaria.supply(parseUnits("1"), exaTime.nextPoolID());
     await auditorUser.enterMarkets(
       [fixedLenderMaria.address],
       exaTime.nextPoolID()
@@ -185,11 +177,7 @@ describe("FixedLender", function () {
     let underlyingTokenUser = underlyingToken.connect(mariaUser);
 
     await underlyingTokenUser.approve(fixedLender.address, parseUnits("1"));
-    await fixedLenderMaria.supply(
-      mariaUser.address,
-      parseUnits("1"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMaria.supply(parseUnits("1"), exaTime.nextPoolID());
     await auditorUser.enterMarkets(
       [fixedLenderMaria.address],
       exaTime.nextPoolID()
@@ -207,11 +195,7 @@ describe("FixedLender", function () {
     let underlyingTokenUser = underlyingToken.connect(mariaUser);
     let notYetEnabledPoolID = exaTime.futurePools(12).pop()! + 86400 * 7; // 1 week after the last pool
     await underlyingTokenUser.approve(fixedLender.address, parseUnits("1"));
-    await fixedLenderMaria.supply(
-      mariaUser.address,
-      parseUnits("1"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMaria.supply(parseUnits("1"), exaTime.nextPoolID());
     await auditorUser.enterMarkets(
       [fixedLenderMaria.address],
       exaTime.nextPoolID()
@@ -230,11 +214,7 @@ describe("FixedLender", function () {
     const invalidPoolID = exaTime.pastPoolID() + 666;
 
     await underlyingTokenUser.approve(fixedLender.address, parseUnits("1"));
-    await fixedLenderMaria.supply(
-      mariaUser.address,
-      parseUnits("1"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMaria.supply(parseUnits("1"), exaTime.nextPoolID());
     await auditorUser.enterMarkets(
       [fixedLenderMaria.address],
       exaTime.nextPoolID()
@@ -261,11 +241,7 @@ describe("FixedLender", function () {
     let underlyingTokenUser = underlyingToken.connect(mariaUser);
 
     await underlyingTokenUser.approve(fixedLender.address, parseUnits("1"));
-    await fixedLenderMaria.supply(
-      mariaUser.address,
-      parseUnits("1"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMaria.supply(parseUnits("1"), exaTime.nextPoolID());
     await auditorUser.enterMarkets(
       [fixedLenderMaria.address],
       exaTime.nextPoolID()
@@ -287,7 +263,6 @@ describe("FixedLender", function () {
     // supply some money and parse event
     await underlyingTokenUser.approve(fixedLender.address, parseUnits("1"));
     let tx = await fixedLenderMaria.supply(
-      mariaUser.address,
       parseUnits("1"),
       exaTime.nextPoolID()
     );
@@ -332,7 +307,6 @@ describe("FixedLender", function () {
     // supply some money and parse event
     await underlyingTokenUser.approve(fixedLender.address, parseUnits("5.0"));
     let txSupply = await fixedLenderMaria.supply(
-      mariaUser.address,
       parseUnits("1"),
       exaTime.nextPoolID()
     );
@@ -373,7 +347,6 @@ describe("FixedLender", function () {
     // supply some money and parse event
     await underlyingTokenUser.approve(fixedLender.address, parseUnits("5.0"));
     let txSupply = await fixedLenderMaria.supply(
-      mariaUser.address,
       parseUnits("1"),
       exaTime.nextPoolID()
     );
@@ -466,17 +439,9 @@ describe("FixedLender", function () {
       parseUnits("1")
     );
 
-    await fixedLenderMariaETH.supply(
-      mariaUser.address,
-      parseUnits("1"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMariaETH.supply(parseUnits("1"), exaTime.nextPoolID());
 
-    await fixedLenderMaria.supply(
-      mariaUser.address,
-      parseUnits("0.2"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMaria.supply(parseUnits("0.2"), exaTime.nextPoolID());
 
     await auditorUser.enterMarkets(
       [fixedLenderMaria.address, fixedLenderMariaETH.address],
@@ -508,17 +473,9 @@ describe("FixedLender", function () {
       parseUnits("1")
     );
 
-    await fixedLenderMariaETH.supply(
-      mariaUser.address,
-      parseUnits("1"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMariaETH.supply(parseUnits("1"), exaTime.nextPoolID());
 
-    await fixedLenderMaria.supply(
-      mariaUser.address,
-      parseUnits("0.2"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMaria.supply(parseUnits("0.2"), exaTime.nextPoolID());
 
     await auditorUser.enterMarkets(
       [fixedLenderMaria.address, fixedLenderMariaETH.address],
@@ -548,11 +505,7 @@ describe("FixedLender", function () {
       parseUnits("1")
     );
 
-    await fixedLenderMariaETH.supply(
-      mariaUser.address,
-      parseUnits("1"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMariaETH.supply(parseUnits("1"), exaTime.nextPoolID());
 
     await auditorUser.enterMarkets(
       [fixedLenderMariaETH.address],
@@ -583,17 +536,9 @@ describe("FixedLender", function () {
       parseUnits("1")
     );
 
-    await fixedLenderMariaETH.supply(
-      mariaUser.address,
-      parseUnits("1"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMariaETH.supply(parseUnits("1"), exaTime.nextPoolID());
 
-    await fixedLenderMaria.supply(
-      mariaUser.address,
-      parseUnits("0.2"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMaria.supply(parseUnits("0.2"), exaTime.nextPoolID());
 
     await auditorUser.enterMarkets(
       [fixedLenderMaria.address, fixedLenderMariaETH.address],
@@ -625,17 +570,9 @@ describe("FixedLender", function () {
       parseUnits("1")
     );
 
-    await fixedLenderMariaETH.supply(
-      mariaUser.address,
-      parseUnits("1"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMariaETH.supply(parseUnits("1"), exaTime.nextPoolID());
 
-    await fixedLenderMaria.supply(
-      mariaUser.address,
-      parseUnits("0.2"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMaria.supply(parseUnits("0.2"), exaTime.nextPoolID());
 
     await auditorUser.enterMarkets(
       [fixedLenderMaria.address, fixedLenderMariaETH.address],
@@ -667,17 +604,9 @@ describe("FixedLender", function () {
       parseUnits("1")
     );
 
-    await fixedLenderMariaETH.supply(
-      mariaUser.address,
-      parseUnits("1"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMariaETH.supply(parseUnits("1"), exaTime.nextPoolID());
 
-    await fixedLenderMaria.supply(
-      mariaUser.address,
-      parseUnits("0.2"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMaria.supply(parseUnits("0.2"), exaTime.nextPoolID());
 
     await auditorUser.enterMarkets(
       [fixedLenderMaria.address, fixedLenderMariaETH.address],
@@ -698,11 +627,7 @@ describe("FixedLender", function () {
 
     expect(debt).not.to.be.equal("0");
 
-    await fixedLenderMaria.supply(
-      mariaUser.address,
-      parseUnits("0.5"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMaria.supply(parseUnits("0.5"), exaTime.nextPoolID());
 
     poolData = await fixedLender.pools(exaTime.nextPoolID());
     debt = poolData[2];
@@ -725,11 +650,7 @@ describe("FixedLender", function () {
       parseUnits("1")
     );
 
-    await fixedLenderMariaETH.supply(
-      mariaUser.address,
-      parseUnits("1"),
-      exaTime.nextPoolID()
-    );
+    await fixedLenderMariaETH.supply(parseUnits("1"), exaTime.nextPoolID());
 
     await auditorUser.enterMarkets(
       [fixedLenderMariaETH.address],

--- a/test/4_liquidity_computation.ts
+++ b/test/4_liquidity_computation.ts
@@ -104,7 +104,7 @@ describe("Liquidity computations", function () {
         await dai.connect(laura).approve(fixedLenderDAI.address, amount);
         const txDai = await fixedLenderDAI
           .connect(laura)
-          .supply(laura.address, amount, nextPoolID);
+          .supply(amount, nextPoolID);
         supplyEvent = await parseSupplyEvent(txDai);
       });
 
@@ -175,9 +175,7 @@ describe("Liquidity computations", function () {
         // laura supplies wbtc to the protocol to have lendable money in the pool
         const amount = parseUnits("3", 8);
         await wbtc.connect(laura).approve(fixedLenderWBTC.address, amount);
-        await fixedLenderWBTC
-          .connect(laura)
-          .supply(laura.address, amount, nextPoolID);
+        await fixedLenderWBTC.connect(laura).supply(amount, nextPoolID);
       });
 
       describe("AND GIVEN Bob provides 60kdai (18 decimals) as collateral", () => {
@@ -187,7 +185,7 @@ describe("Liquidity computations", function () {
             .approve(fixedLenderDAI.address, parseUnits("60000"));
           await fixedLenderDAI
             .connect(bob)
-            .supply(bob.address, parseUnits("60000"), nextPoolID);
+            .supply(parseUnits("60000"), nextPoolID);
         });
         // Here I'm trying to make sure we use the borrowed token's decimals
         // properly to compute liquidity
@@ -213,13 +211,13 @@ describe("Liquidity computations", function () {
             .approve(fixedLenderDAI.address, parseUnits("20000"));
           await fixedLenderDAI
             .connect(bob)
-            .supply(bob.address, parseUnits("20000"), nextPoolID);
+            .supply(parseUnits("20000"), nextPoolID);
           await usdc
             .connect(bob)
             .approve(fixedLenderUSDC.address, parseUnits("40000", 6));
           await fixedLenderUSDC
             .connect(bob)
-            .supply(bob.address, parseUnits("40000", 6), nextPoolID);
+            .supply(parseUnits("40000", 6), nextPoolID);
         });
         describe("AND GIVEN Bob takes a 0.5wbtc loan (200% collateralization)", () => {
           beforeEach(async () => {

--- a/test/5_liquidations.ts
+++ b/test/5_liquidations.ts
@@ -82,17 +82,17 @@ describe("Liquidations", function () {
       // we supply Eth to the protocol
       const amountETH = parseUnits("1");
       await eth.approve(exafinETH.address, amountETH);
-      await exafinETH.supply(alice.address, amountETH, nextPoolID);
+      await exafinETH.connect(alice).supply(amountETH, nextPoolID);
 
       // we supply WBTC to the protocol
       const amountWBTC = parseUnits("1", 8);
       await wbtc.approve(exafinWBTC.address, amountWBTC);
-      await exafinWBTC.supply(alice.address, amountWBTC, nextPoolID);
+      await exafinWBTC.connect(alice).supply(amountWBTC, nextPoolID);
 
       // bob supplies DAI to the protocol to have money in the pool
       const amountDAI = parseUnits("65000");
       await dai.connect(bob).approve(exafinDAI.address, amountDAI);
-      await exafinDAI.connect(bob).supply(bob.address, amountDAI, nextPoolID);
+      await exafinDAI.connect(bob).supply(amountDAI, nextPoolID);
       await dai.connect(bob).approve(exafinDAI.address, parseUnits("100000"));
     });
 

--- a/test/6_rewards_maturity_pool.ts
+++ b/test/6_rewards_maturity_pool.ts
@@ -139,7 +139,7 @@ describe("ExaToken", () => {
         await expect(
           fixedLenderDAI
             .connect(mariaUser)
-            .supply(mariaUser.address, underlyingAmount, exaTime.nextPoolID())
+            .supply(underlyingAmount, exaTime.nextPoolID())
         ).to.emit(auditor, "DistributedSupplierExa");
 
         await auditor.connect(mariaUser).claimExaAll(mariaUser.address);
@@ -157,22 +157,14 @@ describe("ExaToken", () => {
         await dai.approve(fixedLenderDAI.address, underlyingAmount);
 
         await expect(
-          fixedLenderDAI.supply(
-            owner.address,
-            underlyingAmount,
-            exaTime.nextPoolID()
-          )
+          fixedLenderDAI.supply(underlyingAmount, exaTime.nextPoolID())
         ).to.emit(auditor, "DistributedSupplierExa");
       });
 
       it("should DistributedBorrowerExa when borrowing on second interaction", async () => {
         const underlyingAmount = parseUnits("100");
         await dai.approve(fixedLenderDAI.address, underlyingAmount);
-        await fixedLenderDAI.supply(
-          owner.address,
-          underlyingAmount,
-          exaTime.nextPoolID()
-        );
+        await fixedLenderDAI.supply(underlyingAmount, exaTime.nextPoolID());
 
         await expect(
           fixedLenderDAI.borrow(underlyingAmount.div(4), exaTime.nextPoolID())
@@ -194,11 +186,7 @@ describe("ExaToken", () => {
           fixedLenderMaria.address,
           supplyAmount
         );
-        await fixedLenderMaria.supply(
-          mariaUser.address,
-          supplyAmount,
-          exaTime.nextPoolID()
-        );
+        await fixedLenderMaria.supply(supplyAmount, exaTime.nextPoolID());
 
         // Move in time to maturity
         await ethers.provider.send("evm_setNextBlockTimestamp", [
@@ -227,7 +215,6 @@ describe("ExaToken", () => {
         );
         // supply some money and parse event
         await fixedLenderMaria.supply(
-          mariaUser.address,
           underlyingAmount.div(2),
           exaTime.nextPoolID()
         );


### PR DESCRIPTION
### Fixes Issue #69 .

To keep it consistent with function `borrow(uint256 amount, uint256 maturityDate)`, I modified the supply function to receive only two arguments.

**FixedLender** exposes 4 core functions with the following signature:
```
borrow(uint256 amount, uint256 maturityDate)
supply(uint256 amount, uint256 maturityDate)
depositToSmartPool(uint256 amount)
withdrawFromSmartPool(uint256 amount)
```

### New feature
As a future addition, we could later include a third argument describing an `onBehalfOf` address. This would be the address that will receive the eTokens or possible NFT voucher, same as `msg.sender` if the user wants to receive them on his own wallet, or a different address if the beneficiary of eTokens/NFT is a different one.
Strategy from [Aave's V2 Lending Pool](https://github.com/aave/protocol-v2/blob/master/contracts/protocol/lendingpool/LendingPool.sol) ^^.

### Still to do in a following PR
I would also like to know your opinion about renaming the borrow and supply functions (maturity pools) to describe them in a more explicit way and to even write them with same verbs as the ones regarding smart pools.
```
depositToMaturityPool(uint256 amount, uint256 maturityDate)
withdrawFromMaturityPool(uint256 amount, uint256 maturityDate)
```
