### PR TITLE
Changing action to run only when release is created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,20 +4,10 @@ name: Deploy testnet
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  push:
-    branches: main
-
-    # And is tagged with version release/*
-    tags:
-     - 'release/*'
-  pull_request:
-    branches: main
-
-    # And is tagged with version release/*
-    tags:
-     - 'release/*'
-     
+  # Triggers the workflow only when releases are created
+  release:
+    types: [created]
+    
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
This change will only send the `ci` action when a new release is created