### PR TITLE
deploy to a loner node on CI

### DIFF
--- a/.github/workflows/self-deploy.yml
+++ b/.github/workflows/self-deploy.yml
@@ -1,0 +1,32 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Deploy on loner node
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Setup Dependencies
+        run: npm install
+
+      - name: Deploy on loner node
+        run: npm run deploy:hardhat

--- a/deploy/01_exactly.ts
+++ b/deploy/01_exactly.ts
@@ -21,9 +21,18 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const config = YAML.parse(file);
   const [deployer] = await hre.getUnnamedAccounts();
   const tokensForNetwork = config.tokenAddresses[hre.network.name].assets;
-  assert(process.env.MNEMONIC, "include a valid mnemonic in your .env file");
-  assert(process.env.RINKEBY_NODE, "specify a rinkeby node in your .env file");
-  assert(process.env.KOVAN_NODE, "specify a kovan noden your .env file");
+  if (hre.network.name !== "hardhat") {
+    assert(process.env.MNEMONIC, "include a valid mnemonic in your .env file");
+  }
+  if (hre.network.name === "rinkeby") {
+    assert(
+      process.env.RINKEBY_NODE,
+      "specify a rinkeby node in your .env file"
+    );
+  }
+  if (hre.network.name === "kovan") {
+    assert(process.env.KOVAN_NODE, "specify a kovan noden your .env file");
+  }
   if (process.env.FORKING) {
     assert(
       process.env.MAINNET_NODE,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "hardhat test",
     "coverage": "hardhat coverage",
     "deploy:kovan": "hardhat --network kovan deploy",
+    "deploy:hardhat": "hardhat --network hardhat deploy",
     "prepare": "husky install"
   },
   "devDependencies": {


### PR DESCRIPTION
deploy-on-ci
============

TODO
----
- [x] get the deploy to work on a loner, non-forking node
    - [x] deploy mocked assets
    - [x] get it to run
    - [ ] optional: deploy a mocked oracle contract and add some prices
- [x] get github's CI to run the deployment on a loner node
- [x] publish the addresses *only* on release

Why
---
To stop inadvertedly breaking the deploy script in unrelated PRs

How
---
Added a CI task to deploy the contracts to a loner node, and had to introduce a few small modifications to the deploy script to enable it

Up for discussion: Decided to leave actually configuring a working ecosystem for a future PR, if we ever need it.

Action items for that (off the top of my head):
- [ ] deploy a mocked oracle
- [ ] add some pricefeeds
- [ ] add the configs to run the node separately and deploy the contracts there, so it's useful for development

