### PR TITLE
Removed not accurate require

### DIFF
--- a/contracts/FixedLender.sol
+++ b/contracts/FixedLender.sol
@@ -307,11 +307,6 @@ contract FixedLender is IFixedLender, ReentrancyGuard, AccessControl, Pausable {
         totalMpDeposits -= redeemAmount;
         totalMpDepositsUser[redeemer] -= redeemAmount;
 
-        require(
-            trustedUnderlying.balanceOf(address(this)) >= redeemAmount,
-            "Not enough liquidity"
-        );
-
         trustedUnderlying.safeTransfer(redeemer, redeemAmount);
 
         emit WithdrawFromMaturityPool(redeemer, redeemAmount, maturityDate);


### PR DESCRIPTION
Removed block of code that was not tested and was not accurate anymore.

When asking for `balanceOf(address(this))` there's probably going to be liquidity but not necessarily the one that corresponds to a maturity pool to withdraw.