### PR TITLE
ExactlyEnv to be deprecated

### DIFF
--- a/test/0_admin.ts
+++ b/test/0_admin.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { parseUnits } from "@ethersproject/units";
 import { Contract } from "ethers";
-import { ProtocolError, ExactlyEnv, errorGeneric } from "./exactlyUtils";
+import { ProtocolError, errorGeneric } from "./exactlyUtils";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { DefaultEnv } from "./defaultEnv";
 
@@ -34,7 +34,7 @@ describe("Auditor Admin", function () {
   before(async () => {
     [owner, laura] = await ethers.getSigners();
 
-    exactlyEnv = await ExactlyEnv.create({ mockedTokens });
+    exactlyEnv = await DefaultEnv.create({ mockedTokens });
     auditor = exactlyEnv.auditor;
 
     await exactlyEnv.transfer("DAI", laura, "10000");

--- a/test/13_smart_pool.ts
+++ b/test/13_smart_pool.ts
@@ -3,12 +3,7 @@ import { ethers } from "hardhat";
 import { BigNumber, Contract } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import {
-  ExactlyEnv,
-  ExaTime,
-  errorGeneric,
-  ProtocolError,
-} from "./exactlyUtils";
+import { ExaTime, errorGeneric, ProtocolError } from "./exactlyUtils";
 import { DefaultEnv } from "./defaultEnv";
 
 describe("Smart Pool", function () {
@@ -30,7 +25,7 @@ describe("Smart Pool", function () {
   beforeEach(async () => {
     [, bob, john] = await ethers.getSigners();
 
-    exactlyEnv = await ExactlyEnv.create({});
+    exactlyEnv = await DefaultEnv.create({});
     eDAI = exactlyEnv.getEToken("DAI");
     underlyingTokenDAI = exactlyEnv.getUnderlying("DAI");
     fixedLenderDAI = exactlyEnv.getFixedLender("DAI");

--- a/test/15_pausable.ts
+++ b/test/15_pausable.ts
@@ -2,14 +2,12 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { Contract } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { ExactlyEnv, ExaTime } from "./exactlyUtils";
+import { ExaTime } from "./exactlyUtils";
 import { DefaultEnv } from "./defaultEnv";
 
 describe("FixedLender - Pausable", function () {
   let exactlyEnv: DefaultEnv;
-
   let fixedLender: Contract;
-
   let owner: SignerWithAddress;
   let user: SignerWithAddress;
 
@@ -21,7 +19,7 @@ describe("FixedLender - Pausable", function () {
     beforeEach(async () => {
       [owner, user] = await ethers.getSigners();
 
-      exactlyEnv = await ExactlyEnv.create({});
+      exactlyEnv = await DefaultEnv.create({});
       fixedLender = exactlyEnv.getFixedLender("DAI");
       PAUSER_ROLE = await fixedLender.PAUSER_ROLE();
 

--- a/test/16_pool_lib.ts
+++ b/test/16_pool_lib.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { parseUnits } from "ethers/lib/utils";
 import { ethers } from "hardhat";
-import { ExactlyEnv, ExaTime } from "./exactlyUtils";
+import { ExaTime } from "./exactlyUtils";
 import { PoolEnv } from "./poolEnv";
 import { DefaultEnv } from "./defaultEnv";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
@@ -574,7 +574,7 @@ describe("Pool Management Library", () => {
 
   describe("GIVEN that Walter deposits 60000 DAI in the Smart Pool AND 6% penalty rate", () => {
     beforeEach(async () => {
-      defaultEnv = await ExactlyEnv.create({});
+      defaultEnv = await DefaultEnv.create({});
       [, juana, cindy, walter] = await ethers.getSigners();
       await defaultEnv.transfer("ETH", juana, "200");
       await defaultEnv.transfer("DAI", juana, "200");
@@ -833,7 +833,7 @@ describe("Pool Management Library", () => {
 
   describe("GIVEN that Walter deposits 60000 DAI in the Smart Pool AND 6% penalty rate AND 10% borrow rate AND 10% protocol share (for the period, not yearly)", () => {
     beforeEach(async () => {
-      defaultEnv = await ExactlyEnv.create({});
+      defaultEnv = await DefaultEnv.create({});
       [owner, juana, cindy, walter, fakeMultisig] = await ethers.getSigners();
 
       // Juana has ETH to put as collateral, and some DAIf

--- a/test/17_pool_accounting.ts
+++ b/test/17_pool_accounting.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { ProtocolError, errorGeneric, ExactlyEnv } from "./exactlyUtils";
+import { ProtocolError, errorGeneric } from "./exactlyUtils";
 import { DefaultEnv } from "./defaultEnv";
 
 describe("Pool accounting (Admin)", () => {
@@ -10,7 +10,7 @@ describe("Pool accounting (Admin)", () => {
 
   beforeEach(async () => {
     [, laura] = await ethers.getSigners();
-    defaultEnv = await ExactlyEnv.create({});
+    defaultEnv = await DefaultEnv.create({});
   });
 
   describe("function calls not originating from the FixedLender contract", () => {

--- a/test/1_auditor.ts
+++ b/test/1_auditor.ts
@@ -5,7 +5,6 @@ import { Contract } from "ethers";
 import { BigNumber } from "@ethersproject/bignumber";
 import {
   ProtocolError,
-  ExactlyEnv,
   ExaTime,
   errorGeneric,
   applyMinFee,
@@ -29,7 +28,7 @@ describe("Auditor from User Space", function () {
 
     [owner, user] = await ethers.getSigners();
 
-    exactlyEnv = await ExactlyEnv.create({});
+    exactlyEnv = await DefaultEnv.create({});
     auditor = exactlyEnv.auditor;
     nextPoolID = new ExaTime().nextPoolID();
 

--- a/test/2_fixed_lender.ts
+++ b/test/2_fixed_lender.ts
@@ -5,7 +5,6 @@ import {
   errorGeneric,
   errorUnmatchedPool,
   applyMinFee,
-  ExactlyEnv,
   ExaTime,
   PoolState,
   ProtocolError,
@@ -38,7 +37,7 @@ describe("FixedLender", function () {
   beforeEach(async () => {
     [owner, mariaUser, johnUser] = await ethers.getSigners();
 
-    exactlyEnv = await ExactlyEnv.create({});
+    exactlyEnv = await DefaultEnv.create({});
 
     underlyingToken = exactlyEnv.getUnderlying("DAI");
     underlyingTokenETH = exactlyEnv.getUnderlying("ETH");

--- a/test/3_oracle.ts
+++ b/test/3_oracle.ts
@@ -1,12 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { Contract } from "ethers";
-import {
-  errorGeneric,
-  ExactlyEnv,
-  ExaTime,
-  ProtocolError,
-} from "./exactlyUtils";
+import { errorGeneric, ExaTime, ProtocolError } from "./exactlyUtils";
 import { parseUnits } from "ethers/lib/utils";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { DefaultEnv } from "./defaultEnv";
@@ -50,7 +45,7 @@ describe("ExactlyOracle", function () {
 
   before(async () => {
     [, user] = await ethers.getSigners();
-    exactlyEnv = await ExactlyEnv.create({ mockedTokens });
+    exactlyEnv = await DefaultEnv.create({ mockedTokens });
     underlyingToken = exactlyEnv.getUnderlying("DAI");
     const ChainlinkFeedRegistryMock = await ethers.getContractFactory(
       "MockedChainlinkFeedRegistry"

--- a/test/4_liquidity_computation.ts
+++ b/test/4_liquidity_computation.ts
@@ -2,12 +2,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { parseUnits } from "@ethersproject/units";
 import { Contract } from "ethers";
-import {
-  ProtocolError,
-  ExactlyEnv,
-  ExaTime,
-  errorGeneric,
-} from "./exactlyUtils";
+import { ProtocolError, ExaTime, errorGeneric } from "./exactlyUtils";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { DefaultEnv } from "./defaultEnv";
 
@@ -38,7 +33,7 @@ describe("Liquidity computations", function () {
     // laura the lender
     [bob, laura] = await ethers.getSigners();
 
-    exactlyEnv = await ExactlyEnv.create({});
+    exactlyEnv = await DefaultEnv.create({});
     auditor = exactlyEnv.auditor;
 
     fixedLenderDAI = exactlyEnv.getFixedLender("DAI");

--- a/test/5_liquidations.ts
+++ b/test/5_liquidations.ts
@@ -2,12 +2,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { parseUnits } from "@ethersproject/units";
 import { BigNumber, Contract } from "ethers";
-import {
-  ProtocolError,
-  ExactlyEnv,
-  ExaTime,
-  errorGeneric,
-} from "./exactlyUtils";
+import { ProtocolError, ExaTime, errorGeneric } from "./exactlyUtils";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { DefaultEnv } from "./defaultEnv";
 
@@ -38,7 +33,7 @@ describe("Liquidations", function () {
   beforeEach(async () => {
     [alice, bob, john] = await ethers.getSigners();
 
-    exactlyEnv = await ExactlyEnv.create({});
+    exactlyEnv = await DefaultEnv.create({});
     auditor = exactlyEnv.auditor;
 
     fixedLenderETH = exactlyEnv.getFixedLender("ETH");

--- a/test/6_rewards_maturity_pool.ts
+++ b/test/6_rewards_maturity_pool.ts
@@ -1,12 +1,7 @@
 import { ethers } from "hardhat";
 import { expect } from "chai";
 import { BigNumber, Contract } from "ethers";
-import {
-  errorGeneric,
-  ExactlyEnv,
-  ExaTime,
-  ProtocolError,
-} from "./exactlyUtils";
+import { errorGeneric, ExaTime, ProtocolError } from "./exactlyUtils";
 import { parseUnits } from "ethers/lib/utils";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { DefaultEnv } from "./defaultEnv";
@@ -24,7 +19,7 @@ describe("ExaToken", () => {
   let snapshot: any;
 
   beforeEach(async () => {
-    exactlyEnv = await ExactlyEnv.create({});
+    exactlyEnv = await DefaultEnv.create({});
     rewardsLibEnv = await RewardsLibEnv.create();
     [owner, mariaUser, bobUser] = await ethers.getSigners();
     exaToken = exactlyEnv.exaToken;

--- a/test/7_rewards_smart_pool.ts
+++ b/test/7_rewards_smart_pool.ts
@@ -1,7 +1,6 @@
 import { ethers } from "hardhat";
 import { expect } from "chai";
 import { Contract, BigNumber } from "ethers";
-import { ExactlyEnv } from "./exactlyUtils";
 import { parseUnits } from "ethers/lib/utils";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { DefaultEnv } from "./defaultEnv";
@@ -26,7 +25,7 @@ describe("ExaToken Smart Pool", () => {
     let exaToken: Contract;
 
     before(async () => {
-      exactlyEnv = await ExactlyEnv.create({});
+      exactlyEnv = await DefaultEnv.create({});
       dai = exactlyEnv.getUnderlying("DAI");
       eDAI = exactlyEnv.getEToken("DAI");
       fixedLenderDAI = exactlyEnv.getFixedLender("DAI");

--- a/test/8_interest_rate_model.ts
+++ b/test/8_interest_rate_model.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { parseUnits } from "@ethersproject/units";
 import { Contract } from "ethers";
-import { ExactlyEnv, errorGeneric, ProtocolError } from "./exactlyUtils";
+import { errorGeneric, ProtocolError } from "./exactlyUtils";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { parseEther } from "ethers/lib/utils";
 import { DefaultEnv } from "./defaultEnv";
@@ -28,7 +28,7 @@ describe("InterestRateModel", () => {
   beforeEach(async () => {
     [mariaUser] = await ethers.getSigners();
 
-    exactlyEnv = await ExactlyEnv.create({
+    exactlyEnv = await DefaultEnv.create({
       useRealInterestRateModel: true,
     });
 

--- a/test/exactlyUtils.ts
+++ b/test/exactlyUtils.ts
@@ -1,7 +1,5 @@
-import { ethers } from "hardhat";
-import { Contract, BigNumber } from "ethers";
+import { BigNumber } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
-import { DefaultEnv, MockedTokenSpec } from "./defaultEnv";
 
 export interface BorrowFromMaturityPoolEventInterface {
   to: string;
@@ -78,7 +76,13 @@ export type EnvConfig = {
   useRealInterestRateModel?: boolean;
 };
 
-const defaultMockedTokens: Map<string, MockedTokenSpec> = new Map([
+export type MockedTokenSpec = {
+  decimals: BigNumber | number;
+  collateralRate: BigNumber;
+  usdPrice: BigNumber;
+};
+
+export const defaultMockedTokens: Map<string, MockedTokenSpec> = new Map([
   [
     "DAI",
     {
@@ -112,170 +116,6 @@ const defaultMockedTokens: Map<string, MockedTokenSpec> = new Map([
     },
   ],
 ]);
-
-export class ExactlyEnv {
-  static async create({
-    mockedTokens,
-    useRealInterestRateModel,
-  }: EnvConfig): Promise<DefaultEnv> {
-    if (mockedTokens === undefined) {
-      mockedTokens = defaultMockedTokens;
-    }
-    let fixedLenderContracts = new Map<string, Contract>();
-    let poolAccountingContracts = new Map<string, Contract>();
-    let underlyingContracts = new Map<string, Contract>();
-    let eTokenContracts = new Map<string, Contract>();
-
-    const TSUtilsLib = await ethers.getContractFactory("TSUtils");
-    let tsUtils = await TSUtilsLib.deploy();
-    await tsUtils.deployed();
-
-    const ExaLib = await ethers.getContractFactory("ExaLib");
-    let exaLib = await ExaLib.deploy();
-    await exaLib.deployed();
-
-    const PoolLib = await ethers.getContractFactory("PoolLib", {
-      libraries: {
-        TSUtils: tsUtils.address,
-      },
-    });
-    const poolLib = await PoolLib.deploy();
-    await poolLib.deployed();
-
-    const MarketsLib = await ethers.getContractFactory("MarketsLib");
-    let marketsLib = await MarketsLib.deploy();
-    await marketsLib.deployed();
-
-    const ExaToken = await ethers.getContractFactory("ExaToken");
-    let exaToken = await ExaToken.deploy();
-    await exaToken.deployed();
-
-    const MockedOracle = await ethers.getContractFactory("MockedOracle");
-    let oracle = await MockedOracle.deploy();
-    await oracle.deployed();
-
-    const MockedInterestRateModelFactory = await ethers.getContractFactory(
-      "MockedInterestRateModel"
-    );
-
-    const InterestRateModelFactory = await ethers.getContractFactory(
-      "InterestRateModel",
-      {
-        libraries: {
-          TSUtils: tsUtils.address,
-        },
-      }
-    );
-
-    const interestRateModel = useRealInterestRateModel
-      ? await InterestRateModelFactory.deploy(
-          parseUnits("0.07"), // Maturity pool slope rate
-          parseUnits("0.07"), // Smart pool slope rate
-          parseUnits("0.4"), // High UR slope rate
-          parseUnits("0.8"), // Slope change rate
-          parseUnits("0.02"), // Base rate
-          parseUnits("0.02") // Penalty Rate
-        )
-      : await MockedInterestRateModelFactory.deploy();
-    await interestRateModel.deployed();
-
-    const Auditor = await ethers.getContractFactory("Auditor", {
-      libraries: {
-        TSUtils: tsUtils.address,
-        ExaLib: exaLib.address,
-        MarketsLib: marketsLib.address,
-      },
-    });
-    let auditor = await Auditor.deploy(oracle.address, exaToken.address);
-    await auditor.deployed();
-
-    // We have to enable all the FixedLenders in the auditor
-    await Promise.all(
-      Array.from(mockedTokens.keys()).map(async (tokenName) => {
-        const { decimals, collateralRate, usdPrice } =
-          mockedTokens!.get(tokenName)!;
-        const totalSupply = ethers.utils.parseUnits("100000000000", decimals);
-        const MockedToken = await ethers.getContractFactory("MockedToken");
-        const underlyingToken = await MockedToken.deploy(
-          "Fake " + tokenName,
-          "F" + tokenName,
-          decimals,
-          totalSupply.toString()
-        );
-        await underlyingToken.deployed();
-        const MockedEToken = await ethers.getContractFactory("EToken");
-        const eToken = await MockedEToken.deploy(
-          "eFake " + tokenName,
-          "eF" + tokenName,
-          decimals
-        );
-        await eToken.deployed();
-
-        const PoolAccounting = await ethers.getContractFactory(
-          "PoolAccounting",
-          {
-            libraries: {
-              TSUtils: tsUtils.address,
-              PoolLib: poolLib.address,
-            },
-          }
-        );
-        const poolAccounting = await PoolAccounting.deploy(
-          interestRateModel.address
-        );
-
-        const FixedLender = await ethers.getContractFactory("FixedLender");
-        const fixedLender = await FixedLender.deploy(
-          underlyingToken.address,
-          tokenName,
-          eToken.address,
-          auditor.address,
-          poolAccounting.address
-        );
-        await fixedLender.deployed();
-
-        await poolAccounting.initialize(fixedLender.address);
-        await eToken.initialize(fixedLender.address, auditor.address);
-
-        // Mock PriceOracle setting dummy price
-        await oracle.setPrice(tokenName, usdPrice);
-        // Enable Market for FixedLender-TOKEN by setting the collateral rates
-        await auditor.enableMarket(
-          fixedLender.address,
-          collateralRate,
-          tokenName,
-          tokenName,
-          decimals
-        );
-
-        // Handy maps with all the fixedLenders and underlying tokens
-        fixedLenderContracts.set(tokenName, fixedLender);
-        poolAccountingContracts.set(tokenName, poolAccounting);
-        underlyingContracts.set(tokenName, underlyingToken);
-        eTokenContracts.set(tokenName, eToken);
-      })
-    );
-
-    const [owner] = await ethers.getSigners();
-
-    return new DefaultEnv(
-      oracle,
-      auditor,
-      interestRateModel,
-      tsUtils,
-      exaLib,
-      poolLib,
-      marketsLib,
-      exaToken,
-      fixedLenderContracts,
-      poolAccountingContracts,
-      underlyingContracts,
-      eTokenContracts,
-      mockedTokens!,
-      owner
-    );
-  }
-}
 
 export class ExaTime {
   timestamp: number;


### PR DESCRIPTION
* `ExactlyEnv` was still creating the `DefaultEnv`
* We moved the static `create()` method to `DefaultEnv` and removed `ExactlyEnv` from exactlyUtils