### PR TITLE
Changes for PoolAccounting tests

### DIFF
--- a/contracts/InterestRateModel.sol
+++ b/contracts/InterestRateModel.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.4;
 
-import "./interfaces/IInterestRateModel.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
+
+import "./interfaces/IInterestRateModel.sol";
 import "./utils/Errors.sol";
 import "./utils/DecimalMath.sol";
-import "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract InterestRateModel is IInterestRateModel, AccessControl {
     using PoolLib for PoolLib.MaturityPool;
@@ -16,21 +17,23 @@ contract InterestRateModel is IInterestRateModel, AccessControl {
     uint256 public curveParameterA;
     int256 public curveParameterB;
     uint256 public maxUtilizationRate;
+    uint256 public spFeeRate;
     uint256 public override penaltyRate;
-    uint256 public spFeeRate = 1e17; // 10%
 
     constructor(
         uint256 _curveParameterA,
         int256 _curveParameterB,
         uint256 _maxUtilizationRate,
-        uint256 _penaltyRate
+        uint256 _penaltyRate,
+        uint256 _spFeeRate
     ) {
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
         setParameters(
             _curveParameterA,
             _curveParameterB,
             _maxUtilizationRate,
-            _penaltyRate
+            _penaltyRate,
+            _spFeeRate
         );
     }
 
@@ -44,23 +47,19 @@ contract InterestRateModel is IInterestRateModel, AccessControl {
      */
     function getYieldForDeposit(
         uint256 suppliedSP,
-        uint256 borrowed,
         uint256 unassignedEarnings,
-        uint256 amount,
-        uint256 mpDepositsWeighter
+        uint256 amount
     )
         external
         view
         override
         returns (uint256 earningsShare, uint256 earningsShareSP)
     {
-        if (borrowed != 0) {
-            amount = amount.mul_(mpDepositsWeighter);
+        if (suppliedSP != 0) {
             // User can't make more fees after the total borrowed amount
-            earningsShare = ((Math.min(amount, borrowed) * unassignedEarnings) /
-                borrowed);
-            earningsShareSP = ((suppliedSP * unassignedEarnings) / borrowed)
-                .mul_(spFeeRate);
+            earningsShare = ((Math.min(amount, suppliedSP) *
+                unassignedEarnings) / suppliedSP);
+            earningsShareSP = earningsShare.mul_(spFeeRate);
             earningsShare -= earningsShareSP;
         }
     }
@@ -71,17 +70,20 @@ contract InterestRateModel is IInterestRateModel, AccessControl {
      * @param _curveParameterB curve parameter
      * @param _maxUtilizationRate % of MP supp
      * @param _penaltyRate by-second rate charged on late repays, with 18 decimals
+     * @param _spFeeRate rate charged to the mp depositors to be accrued by the sp borrowers
      */
     function setParameters(
         uint256 _curveParameterA,
         int256 _curveParameterB,
         uint256 _maxUtilizationRate,
-        uint256 _penaltyRate
+        uint256 _penaltyRate,
+        uint256 _spFeeRate
     ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         curveParameterA = _curveParameterA;
         curveParameterB = _curveParameterB;
         maxUtilizationRate = _maxUtilizationRate;
         penaltyRate = _penaltyRate;
+        spFeeRate = _spFeeRate;
         // we call the getRateToBorrow function with an utilization rate of
         // zero to force it to revert in the tx that sets it, and not be able
         // to set an invalid curve (such as one yielding a negative interest

--- a/contracts/external/MockedInterestRateModel.sol
+++ b/contracts/external/MockedInterestRateModel.sol
@@ -29,10 +29,8 @@ contract MockedInterestRateModel is IInterestRateModel {
 
     function getYieldForDeposit(
         uint256 suppliedSP,
-        uint256 borrowed,
         uint256 unassignedEarnings,
-        uint256 amount,
-        uint256 mpDepositsWeighter
+        uint256 amount
     )
         external
         view
@@ -44,19 +42,13 @@ contract MockedInterestRateModel is IInterestRateModel {
         return
             realInterestRateModel.getYieldForDeposit(
                 suppliedSP,
-                borrowed,
                 unassignedEarnings,
-                amount,
-                mpDepositsWeighter
+                amount
             );
     }
 
     function setBorrowRate(uint256 newRate) public {
         borrowRate = newRate;
-    }
-
-    function setSPFeeRate(uint256 newRate) public {
-        spFeeRate = newRate;
     }
 
     function setPenaltyRate(uint256 newRate) public {

--- a/contracts/external/PoolAccountingHarness.sol
+++ b/contracts/external/PoolAccountingHarness.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.4;
 
 import "../PoolAccounting.sol";
 import "../interfaces/IFixedLender.sol";
-import "hardhat/console.sol";
 
 contract PoolAccountingHarness is PoolAccounting {
     struct ReturnValues {
@@ -18,13 +17,9 @@ contract PoolAccountingHarness is PoolAccounting {
 
     ReturnValues public returnValues;
     uint256 public timestamp;
-    IFixedLender public fixedLender;
 
-    constructor(address interestRateModel, address fixedLenderAddress)
-        PoolAccounting(interestRateModel)
-    {
+    constructor(address interestRateModel) PoolAccounting(interestRateModel) {
         timestamp = block.timestamp;
-        fixedLender = IFixedLender(fixedLenderAddress);
     }
 
     function borrowMPWithReturnValues(
@@ -89,10 +84,6 @@ contract PoolAccountingHarness is PoolAccounting {
 
     function setCurrentTimestamp(uint256 _timestamp) external {
         timestamp = _timestamp;
-    }
-
-    function mpDepositDistributionWeighter() external view returns (uint256) {
-        return fixedLender.mpDepositDistributionWeighter();
     }
 
     function currentTimestamp() internal view override returns (uint256) {

--- a/contracts/interfaces/IInterestRateModel.sol
+++ b/contracts/interfaces/IInterestRateModel.sol
@@ -16,9 +16,7 @@ interface IInterestRateModel {
 
     function getYieldForDeposit(
         uint256 suppliedSP,
-        uint256 borrowed,
         uint256 unassignedEarnings,
-        uint256 amount,
-        uint256 mpDepositsWeighter
+        uint256 amount
     ) external view returns (uint256 earningsShare, uint256 earningsShareSP);
 }

--- a/contracts/utils/PoolLib.sol
+++ b/contracts/utils/PoolLib.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.4;
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./TSUtils.sol";
 import "./Errors.sol";
-import "hardhat/console.sol";
 
 library PoolLib {
     /**

--- a/test/poolAccountingEnv.ts
+++ b/test/poolAccountingEnv.ts
@@ -7,19 +7,16 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 export class PoolAccountingEnv {
   interestRateModel: Contract;
   poolAccountingHarness: Contract;
-  fixedLender: Contract;
   currentWallet: SignerWithAddress;
   maxSPDebt = parseUnits("100000");
 
   constructor(
     _interestRateModel: Contract,
     _poolAccountingHarness: Contract,
-    _fixedLender: Contract,
     _currentWallet: SignerWithAddress
   ) {
     this.interestRateModel = _interestRateModel;
     this.poolAccountingHarness = _poolAccountingHarness;
-    this.fixedLender = _fixedLender;
     this.currentWallet = _currentWallet;
   }
 
@@ -117,7 +114,8 @@ export class PoolAccountingEnv {
       parseUnits("0.07"), // Maturity pool slope rate
       parseUnits("0.07"), // Smart pool slope rate
       parseUnits("0.02"), // Base rate
-      parseUnits("0.0000002315") // Penalty Rate per second (86400 is ~= 2%)
+      parseUnits("0.0000002315"), // Penalty Rate per second (86400 is ~= 2%)
+      parseUnits("0") // SP rate if 0 then no fees charged for the mp depositors' yield
     );
 
     // MockedInterestRateModel is wrapping the real IRM since getYieldToDeposit
@@ -148,17 +146,6 @@ export class PoolAccountingEnv {
       interestRateModel.address
     );
     await realPoolAccounting.deployed();
-    const FixedLender = await ethers.getContractFactory("FixedLender");
-    const addressZero = "0x0000000000000000000000000000000000000000";
-    // We only deploy a FixedLender to be able to access mpDepositDistributionWeighter parameter and to also call setMpDepositDistributionWeighter
-    const fixedLender = await FixedLender.deploy(
-      addressZero,
-      "DAI",
-      addressZero,
-      addressZero,
-      addressZero
-    );
-    await fixedLender.deployed();
     const PoolAccountingHarness = await ethers.getContractFactory(
       "PoolAccountingHarness",
       {
@@ -169,8 +156,7 @@ export class PoolAccountingEnv {
       }
     );
     const poolAccountingHarness = await PoolAccountingHarness.deploy(
-      interestRateModel.address,
-      fixedLender.address
+      interestRateModel.address
     );
     await poolAccountingHarness.deployed();
     // We initialize it with itself, so it can call the methods from within
@@ -181,7 +167,6 @@ export class PoolAccountingEnv {
     return new PoolAccountingEnv(
       interestRateModel,
       poolAccountingHarness,
-      fixedLender,
       owner
     );
   }


### PR DESCRIPTION
- Added `_spFeeRate` setter in IRM constructor (new gamma, should correctly test this in a future PR)
- Removed weighter usage from IRM, should also remove the variable from FixedLender in a future PR (previous gamma)
- Updated `getYieldForDeposit` function to new impl. Should unit test this in a future PR.
- Updated tests for `PoolAccounting` file suite
- I still have to add the 'market clearing' tests for the PoolAccounting @lucaslain (the ones we talked about earlier)