### PR TITLE
Test for Santy on "money on the table" situation

### DIFF
--- a/test/17_pool_accounting.ts
+++ b/test/17_pool_accounting.ts
@@ -1394,7 +1394,7 @@ describe("PoolAccounting", () => {
           expect(mp.suppliedSP).to.eq(parseUnits("4772.727272727272727272"));
         });
         it("THEN the redeemAmountDiscounted returned is 4772", async () => {
-          // 5250 / 1.10 (1e18 + 5e16 feeRate) = 4772.72727272727272727272
+          // 5250 / 1.10 (1e18 + 1e17 feeRate) = 4772.72727272727272727272
           expect(returnValues.redeemAmountDiscounted).to.be.eq(
             parseUnits("4772.727272727272727272")
           );


### PR DESCRIPTION
* Failing test where the supply of the smart pool should be less than the withdrawn money
  * User deposits 5000 and takes 250 fees (approximately 5%)
  * Borrow Rates go to 10%
  * User wants to withdraw 5250 (5250 / 1.1 = 4772 which is less than the principal)
  * The SP takes that debt, to buy the 5250 and set unassigned earnings for the difference (in case another depositor wants to come)