### PR TITLE
👷 github: push release commits using custom token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PR_GITHUB_TOKEN }}
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
this is supposed to fix the current issue of the release pr not triggering the test workflow:

<img width="1058" alt="Screenshot 2023-04-12 at 19 23 50" src="https://user-images.githubusercontent.com/216636/231599514-6720260d-7f58-4aa8-abb0-33760c92d838.png">

reference: https://github.com/changesets/action/issues/187#issuecomment-1228413850