### PR TITLE
🔧 finance: new parameters

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -72,7 +72,7 @@ export default {
       WETH: {
         adjustFactor: 0.84,
         floatingCurve: { a: 1.9362e-2, b: -1.787e-3, maxUtilization: 1.003870947 },
-        fixedCurve: { a: 3.8126e-1, b: -3.6375e-1, maxUtilization: 1.000010695 },
+        fixedCurve: { a: 3.8691e-1, b: -3.5319e-1, maxUtilization: 1.031219287 },
         overrides: {
           goerli: {
             rewards: { OP: { total: 120_000, debt: 16_000, start: "2023-03-09", period: 16 * 7 * 86_400 } },
@@ -97,12 +97,12 @@ export default {
         networks: ["mainnet", "goerli"],
         adjustFactor: 0.9,
         floatingCurve: { a: 1.7852e-2, b: -2.789e-3, maxUtilization: 1.003568501 },
-        fixedCurve: { a: 3.9281e-1, b: -3.7781e-1, maxUtilization: 1.000014451 },
+        fixedCurve: { a: 3.6909e-1, b: -3.3415e-1, maxUtilization: 1.02766986 },
       },
       USDC: {
         adjustFactor: 0.91,
         floatingCurve: { a: 1.4844e-2, b: 1.9964e-4, maxUtilization: 1.002968978 },
-        fixedCurve: { a: 3.9281e-1, b: -3.7781e-1, maxUtilization: 1.000014451 },
+        fixedCurve: { a: 2.5931e-1, b: -2.3207e-1, maxUtilization: 1.008715115 },
         overrides: {
           goerli: {
             rewards: { OP: { total: 280_000, debt: 25_000_000, start: "2023-03-09", period: 16 * 7 * 86_400 } },
@@ -125,7 +125,7 @@ export default {
       wstETH: {
         adjustFactor: 0.82,
         floatingCurve: { a: 1.9362e-2, b: -1.787e-3, maxUtilization: 1.003870947 },
-        fixedCurve: { a: 3.8126e-1, b: -3.6375e-1, maxUtilization: 1.000010695 },
+        fixedCurve: { a: 3.8691e-1, b: -3.5319e-1, maxUtilization: 1.031219287 },
         priceFeed: { wrapper: "stETH", fn: "getPooledEthByShares", baseUnit: 10n ** 18n },
         overrides: {
           goerli: {
@@ -162,7 +162,7 @@ export default {
         networks: ["optimism"],
         adjustFactor: 0.58,
         floatingCurve: { a: 2.8487e-2, b: -5.8259e-3, maxUtilization: 1.005690787 },
-        fixedCurve: { a: 3.5815e-1, b: -3.3564e-1, maxUtilization: 1.000005527 },
+        fixedCurve: { a: 2.8574e-1, b: -2.4204e-1, maxUtilization: 1.013118138 },
       },
     },
   },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -23,7 +23,12 @@ export default {
     settings: { optimizer: { enabled: true, runs: 200 }, debug: { revertStrings: "strip" } },
   },
   networks: {
-    mainnet: { priceDecimals: 18, timelockDelay: 24 * 3_600, url: env.MAINNET_NODE ?? "", finance: { futurePools: 3 } },
+    mainnet: {
+      priceDecimals: 18,
+      timelockDelay: 24 * 3_600,
+      finance: { treasuryFeeRate: 0, futurePools: 3 },
+      url: env.MAINNET_NODE ?? "",
+    },
     optimism: { priceDecimals: 8, timelockDelay: 24 * 3_600, url: env.OPTIMISM_NODE ?? "" },
     goerli: { priceDecimals: 8, url: env.GOERLI_NODE ?? "" },
   },
@@ -40,8 +45,13 @@ export default {
       optimism: "0xC0d6Bc5d052d1e74523AD79dD5A954276c9286D3",
       goerli: "0x1801f5EAeAbA3fD02cBF4b7ED1A7b58AD84C0705",
     },
+    treasury: {
+      optimism: "0x23fD464e0b0eE21cEdEb929B19CABF9bD5215019",
+      goerli: "0x1801f5EAeAbA3fD02cBF4b7ED1A7b58AD84C0705",
+    },
   },
   finance: {
+    treasuryFeeRate: 0.15,
     liquidationIncentive: { liquidator: 0.05, lenders: 0.0025 },
     penaltyRatePerDay: 0.0045,
     backupFeeRate: 0.1,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -128,7 +128,34 @@ export default {
         fixedCurve: { a: 3.8126e-1, b: -3.6375e-1, maxUtilization: 1.000010695 },
         priceFeed: { wrapper: "stETH", fn: "getPooledEthByShares", baseUnit: 10n ** 18n },
         overrides: {
-          optimism: { adjustFactor: 0.8, priceFeed: undefined },
+          goerli: {
+            rewards: {
+              OP: {
+                total: 7,
+                debt: 1,
+                start: "2023-06-13",
+                period: 4 * 7 * 86_400,
+                compensationFactor: 0,
+                transitionFactor: 0.64,
+                depositAllocationWeightAddend: 0.03,
+              },
+            },
+          },
+          optimism: {
+            adjustFactor: 0.8,
+            priceFeed: undefined,
+            rewards: {
+              OP: {
+                total: 5_000,
+                debt: 1,
+                start: "2023-06-26T14:00Z",
+                period: 4 * 7 * 86_400,
+                compensationFactor: 0,
+                transitionFactor: 0.64,
+                depositAllocationWeightAddend: 0.03,
+              },
+            },
+          },
         },
       },
       OP: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -75,15 +75,15 @@ export default {
         fixedCurve: { a: 3.8126e-1, b: -3.6375e-1, maxUtilization: 1.000010695 },
         overrides: {
           goerli: {
-            rewards: { OP: { total: 90_000, debt: 16_000, start: "2023-03-09", period: 12 * 7 * 86_400 } },
+            rewards: { OP: { total: 120_000, debt: 16_000, start: "2023-03-09", period: 16 * 7 * 86_400 } },
           },
           optimism: {
             rewards: {
               OP: {
-                total: 90_000,
+                total: 120_000,
                 debt: 1_666,
                 start: "2023-04-03T14:00Z",
-                period: 12 * 7 * 86_400,
+                period: 16 * 7 * 86_400,
                 undistributedFactor: 0.3,
                 compensationFactor: 0.7,
                 transitionFactor: 0.7056,
@@ -105,10 +105,10 @@ export default {
         fixedCurve: { a: 3.9281e-1, b: -3.7781e-1, maxUtilization: 1.000014451 },
         overrides: {
           goerli: {
-            rewards: { OP: { total: 210_000, debt: 25_000_000, start: "2023-03-09", period: 12 * 7 * 86_400 } },
+            rewards: { OP: { total: 280_000, debt: 25_000_000, start: "2023-03-09", period: 16 * 7 * 86_400 } },
           },
           optimism: {
-            rewards: { OP: { total: 210_000, debt: 7_500_000, start: "2023-04-03T14:00Z", period: 12 * 7 * 86_400 } },
+            rewards: { OP: { total: 280_000, debt: 7_500_000, start: "2023-04-03T14:00Z", period: 16 * 7 * 86_400 } },
           },
         },
       },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -70,7 +70,7 @@ export default {
     },
     markets: {
       WETH: {
-        adjustFactor: 0.84,
+        adjustFactor: 0.86,
         floatingCurve: { a: 1.9362e-2, b: -1.787e-3, maxUtilization: 1.003870947 },
         fixedCurve: { a: 3.8691e-1, b: -3.5319e-1, maxUtilization: 1.031219287 },
         overrides: {
@@ -142,7 +142,6 @@ export default {
             },
           },
           optimism: {
-            adjustFactor: 0.8,
             priceFeed: undefined,
             rewards: {
               OP: {


### PR DESCRIPTION
# changes
- enable treasury (15%)
- extend rewards distribution period (+4 weeks, +100k `OP`)
- enable `wstETH` rewards (4 weeks, 5k `OP`)
- set new interest rate model parameters (`WETH`, `DAI`, `USDC`, `wstETH` and `OP` fixed curves)
- set new adjust factors (`WETH` to `0.86` and `wstETH` to `0.82`)

all changes are already deployed to goerli