### PR TITLE
🔧 finance: enable `EXA` rewards and extend current period

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -75,15 +75,17 @@ export default {
         fixedCurve: { a: 3.8691e-1, b: -3.5319e-1, maxUtilization: 1.031219287 },
         overrides: {
           goerli: {
-            rewards: { OP: { total: 120_000, debt: 16_000, start: "2023-03-09", period: 16 * 7 * 86_400 } },
+            rewards: {
+              OP: { total: 150_000, debt: 16_000, start: "2023-03-09", period: 20 * 7 * 86_400 },
+            },
           },
           optimism: {
             rewards: {
               OP: {
-                total: 120_000,
+                total: 150_000,
                 debt: 1_666,
                 start: "2023-04-03T14:00Z",
-                period: 16 * 7 * 86_400,
+                period: 20 * 7 * 86_400,
                 undistributedFactor: 0.3,
                 compensationFactor: 0.7,
                 transitionFactor: 0.7056,
@@ -105,10 +107,14 @@ export default {
         fixedCurve: { a: 2.5931e-1, b: -2.3207e-1, maxUtilization: 1.008715115 },
         overrides: {
           goerli: {
-            rewards: { OP: { total: 280_000, debt: 25_000_000, start: "2023-03-09", period: 16 * 7 * 86_400 } },
+            rewards: {
+              OP: { total: 350_000, debt: 25_000_000, start: "2023-03-09", period: 20 * 7 * 86_400 },
+            },
           },
           optimism: {
-            rewards: { OP: { total: 280_000, debt: 7_500_000, start: "2023-04-03T14:00Z", period: 16 * 7 * 86_400 } },
+            rewards: {
+              OP: { total: 350_000, debt: 7_500_000, start: "2023-04-03T14:00Z", period: 20 * 7 * 86_400 },
+            },
           },
         },
       },
@@ -131,10 +137,10 @@ export default {
           goerli: {
             rewards: {
               OP: {
-                total: 7,
+                total: 14,
                 debt: 1,
                 start: "2023-06-13",
-                period: 4 * 7 * 86_400,
+                period: 8 * 7 * 86_400,
                 compensationFactor: 0,
                 transitionFactor: 0.64,
                 depositAllocationWeightAddend: 0.03,
@@ -145,10 +151,10 @@ export default {
             priceFeed: undefined,
             rewards: {
               OP: {
-                total: 5_000,
+                total: 10_000,
                 debt: 1,
                 start: "2023-06-26T14:00Z",
-                period: 4 * 7 * 86_400,
+                period: 8 * 7 * 86_400,
                 compensationFactor: 0,
                 transitionFactor: 0.64,
                 depositAllocationWeightAddend: 0.03,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -77,6 +77,7 @@ export default {
           goerli: {
             rewards: {
               OP: { total: 150_000, debt: 16_000, start: "2023-03-09", period: 20 * 7 * 86_400 },
+              EXA: { total: 7_200, debt: 16_000, start: "2023-07-20", period: 4 * 7 * 86_400 },
             },
           },
           optimism: {
@@ -86,6 +87,16 @@ export default {
                 debt: 1_666,
                 start: "2023-04-03T14:00Z",
                 period: 20 * 7 * 86_400,
+                undistributedFactor: 0.3,
+                compensationFactor: 0.7,
+                transitionFactor: 0.7056,
+                depositAllocationWeightAddend: 0.03,
+              },
+              EXA: {
+                total: 7_200,
+                debt: 1_666,
+                start: "2023-07-24T14:00Z",
+                period: 4 * 7 * 86_400,
                 undistributedFactor: 0.3,
                 compensationFactor: 0.7,
                 transitionFactor: 0.7056,
@@ -109,11 +120,13 @@ export default {
           goerli: {
             rewards: {
               OP: { total: 350_000, debt: 25_000_000, start: "2023-03-09", period: 20 * 7 * 86_400 },
+              EXA: { total: 14_400, debt: 25_000_000, start: "2023-07-20", period: 4 * 7 * 86_400 },
             },
           },
           optimism: {
             rewards: {
               OP: { total: 350_000, debt: 7_500_000, start: "2023-04-03T14:00Z", period: 20 * 7 * 86_400 },
+              EXA: { total: 14_400, debt: 7_500_000, start: "2023-07-24T14:00Z", period: 4 * 7 * 86_400 },
             },
           },
         },
@@ -145,6 +158,15 @@ export default {
                 transitionFactor: 0.64,
                 depositAllocationWeightAddend: 0.03,
               },
+              EXA: {
+                total: 7,
+                debt: 1,
+                start: "2023-07-20",
+                period: 4 * 7 * 86_400,
+                compensationFactor: 0,
+                transitionFactor: 0.64,
+                depositAllocationWeightAddend: 0.03,
+              },
             },
           },
           optimism: {
@@ -155,6 +177,15 @@ export default {
                 debt: 1,
                 start: "2023-06-26T14:00Z",
                 period: 8 * 7 * 86_400,
+                compensationFactor: 0,
+                transitionFactor: 0.64,
+                depositAllocationWeightAddend: 0.03,
+              },
+              EXA: {
+                total: 2_400,
+                debt: 1,
+                start: "2023-07-24T14:00Z",
+                period: 4 * 7 * 86_400,
                 compensationFactor: 0,
                 transitionFactor: 0.64,
                 depositAllocationWeightAddend: 0.03,
@@ -171,6 +202,16 @@ export default {
         overrides: {
           optimism: {
             rewards: {
+              EXA: {
+                total: 1_000,
+                debt: 100_000,
+                start: "2023-07-24T14:00Z",
+                period: 4 * 7 * 86_400,
+                undistributedFactor: 0.3,
+                compensationFactor: 0.7,
+                transitionFactor: 0.7056,
+                depositAllocationWeightAddend: 0.03,
+              },
             },
           },
         },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -168,6 +168,12 @@ export default {
         adjustFactor: 0.58,
         floatingCurve: { a: 2.8487e-2, b: -5.8259e-3, maxUtilization: 1.005690787 },
         fixedCurve: { a: 2.8574e-1, b: -2.4204e-1, maxUtilization: 1.013118138 },
+        overrides: {
+          optimism: {
+            rewards: {
+            },
+          },
+        },
       },
     },
     periphery: {

--- a/test/19_rewards_controller.ts
+++ b/test/19_rewards_controller.ts
@@ -47,7 +47,9 @@ describe("RewardsController", function () {
     });
     it("THEN the claimable amount is positive", async () => {
       const claimableBalance = await rewardsController.allClaimable(alice.address, op.address);
-      await rewardsController.claimAll(alice.address);
+      await rewardsController.claim([{ market: marketUSDC.address, operations: [false, true] }], alice.address, [
+        op.address,
+      ]);
       const claimedBalance = await op.balanceOf(alice.address);
 
       expect(claimableBalance).to.be.greaterThan(0);


### PR DESCRIPTION
# changes
- add `105_000` `OP` rewards for 4 more weeks:
  - `30_000` `OP` more for `WETH`
  - `70_000` `OP` more for `USDC`
  - `5_000` `OP` more for `wstETH`
- add `25_000` `EXA` rewards for 4 weeks (starting on monday, `2023-07-24`, 14:00 UTC):
  - `7_200` `EXA` for `WETH`
  - `14_400` `EXA` for `USDC`
  - `2_400` `EXA` for `wstETH`
  - `1_000` `EXA` for `OP`